### PR TITLE
release 0.116.0-alpha1 to nixos and set current stable to 0.115.3

### DIFF
--- a/upwind-sensor/upwind-version.nix
+++ b/upwind-sensor/upwind-version.nix
@@ -24,7 +24,7 @@
         arm64 = "f6dc098e168e402f0061567f8367ffcee9e12bfdbdfb9fe4068f08093c9c2025";
       };
       "0.116.0-alpha1" = {
-        amd64 = "";
+        amd64 = "2d037872bd09ac4b38ea6823bbf875277e00ea4eed8a9098b854b476637ce20c";
         arm64 = "bd9814046197bb9b462e8cc3aa25515262a72fa6f41320b0a85d6577bb685089";
       };
     };


### PR DESCRIPTION
Releases 0.116.0-alpha1 to nixos for testing, and updates latest stable to 0.115.3.
