### PR TITLE
feat: extra configuration

### DIFF
--- a/upwind-sensor/README.md
+++ b/upwind-sensor/README.md
@@ -28,12 +28,21 @@ in {
   services.upwindSensor = {
     enable = true;
     enableScanner = true;
-    sensorVersion = "0.111.2";   # (Optional) pin sensor/scanner version
+    sensorVersion = "0.115.3";   # (Optional) pin sensor/scanner version
     region = "us";               # Change to "eu" if needed
     logLevel = "info";
+    sensorEnvironment = {        # (Optional) additional env vars for sensor service
+      EXAMPLE_VAR = "example";
+    };
+    scannerEnvironment = {       # (Optional) additional env vars for scanner service
+      EXAMPLE_VAR = "example";
+    };
+    extraConfig = {              # (Optional) extra config for agent.yaml file
+      example = true;
+    };
     environmentFile = [
       /path/to/credentials.env   # Contains the credential env vars
-    ]
+    ];
   };
 }
 ```

--- a/upwind-sensor/upwind-version.nix
+++ b/upwind-sensor/upwind-version.nix
@@ -20,8 +20,8 @@
         arm64 = "4d9f2e12c57ed9374c532790f2e200b0d5d11cfa7627ace7f336ebacbebd3cb4";
       };
       "0.115.3" = {
-        amd64 = "690bb87285595c010cca7f0bff7defaef95b899000c03bf553b1bd9cbd53dd25";
-        arm64 = "f6dc098e168e402f0061567f8367ffcee9e12bfdbdfb9fe4068f08093c9c2025";
+        amd64 = "c9a037b66455fc9ab9ddfc719628154ab7f9495bb4efafb4ab0a8eb159539a53";
+        arm64 = "bed4f044859747755af52cd9b93f8a8b3f0ce3d1c477498add604b1a1e8ac2d0";
       };
       "0.116.0-alpha1" = {
         amd64 = "2d037872bd09ac4b38ea6823bbf875277e00ea4eed8a9098b854b476637ce20c";


### PR DESCRIPTION
Adds the `extraConfig` attribute set for key/values to add to the agent.yaml.

Also adds `sensorEnvironment` and `scannerEnvironment` attribute sets to specify additional environment variables on the services themselves if that is needed. Typically `extraConfig` alone should be sufficient.

Lastly, updates the hashes for 0.115.3 since it was rebuilt.